### PR TITLE
make mirror process more resilient

### DIFF
--- a/pkg/mirror/repo_pool.go
+++ b/pkg/mirror/repo_pool.go
@@ -2,6 +2,7 @@ package mirror
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -13,8 +14,8 @@ import (
 )
 
 var (
-	ErrExist    = fmt.Errorf("repo already exist")
-	ErrNotExist = fmt.Errorf("repo does not exist")
+	ErrExist    = errors.New("repo already exist")
+	ErrNotExist = errors.New("repo does not exist")
 )
 
 // RepoPool represents the collection of mirrored repositories


### PR DESCRIPTION
1) if repo level jobs failed continue processing another repo 
2) if worktree level job failed keep old worktree  and
   also process another worktree in repo.