### PR TITLE
Set WaitDelay on the git command

### DIFF
--- a/pkg/mirror/helper.go
+++ b/pkg/mirror/helper.go
@@ -200,6 +200,8 @@ func runGitCommand(ctx context.Context, log *slog.Logger, envs []string, cwd str
 	log.Log(ctx, -8, "running command", "cwd", cwd, "cmd", cmdStr)
 
 	cmd := exec.CommandContext(ctx, gitExecutablePath, args...)
+	// force kill git 5 seconds after sending it sigterm
+	cmd.WaitDelay = 5 * time.Second
 	if cwd != "" {
 		cmd.Dir = cwd
 	}


### PR DESCRIPTION
So we don't wait indefinitely for the git command to finish after we send the sigterm signal to it on context cancel.